### PR TITLE
fix(ci): replace target branch from master to main

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,7 +3,7 @@ name: github pages
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy:


### PR DESCRIPTION
## Why

The CI workflow had master as the branch that triggers the deploy Action and this branch has been renamed to main.

## What

Change the Action to listen the main branch.